### PR TITLE
Fix incomplete warn msg when msg is mulitiline.

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -146,8 +146,9 @@ module.exports = {
     // because someone thought it was a good idea to reverse the order of data
     // in warning messages versus error messages
     for (const warning of stats.warnings) {
-      const lines = warning.split('\n');
-      const [file, message] = lines;
+      const warpPosition = warning.indexOf('\n');
+      const file = warning.slice(0, warpPosition);
+      const message = warning.slice(warpPosition + 1);
       const problem = probs[file] || { errors: [], warnings: [] };
       const [,, line, column] = message.match(rePosition) || [0, 0, 0, 0];
       const item = { message: message.replace(rePosition, '').trim(), line, column };

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -146,9 +146,9 @@ module.exports = {
     // because someone thought it was a good idea to reverse the order of data
     // in warning messages versus error messages
     for (const warning of stats.warnings) {
-      const warpPosition = warning.indexOf('\n');
-      const file = warning.slice(0, warpPosition);
-      const message = warning.slice(warpPosition + 1);
+      const lines = warning.split('\n');
+      const [file] = lines;
+      const message = lines.slice(1, lines.length - 1).join(' ');
       const problem = probs[file] || { errors: [], warnings: [] };
       const [,, line, column] = message.match(rePosition) || [0, 0, 0, 0];
       const item = { message: message.replace(rePosition, '').trim(), line, column };


### PR DESCRIPTION
<!--
  ZOMG a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and @ken_wheeler
  will appear and pile-drive the close button from a great height while making
  animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

When we have multiline warning messages, it will be imcomplete because of:

```js
const lines = warning.split('\n');
const [file, message] = lines;
```

Here is the result: 
![image](https://user-images.githubusercontent.com/9346008/36354926-73ae29b8-1516-11e8-99c7-edde68d61aff.png)

So I changed these code, to make the multiline warning messages display completely.

![image](https://user-images.githubusercontent.com/9346008/36354946-c4c6dcf0-1516-11e8-813c-73cb7d739d5c.png)<sub>This result also removed `warp` function</sub>


### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

No

### Additional Info

I don't know what the `wrap` function in `style.js` does in this situation:

```js
for (const item of problem[type]) {
  const message = wrap(item.message);
  // ...
}
```

`wrap` function removed the messages indent, make console displayed like this:
![image](https://user-images.githubusercontent.com/9346008/36355035-d4507c66-1517-11e8-9c27-ea92fd8f61c2.png)

So I would keep `wrap` function there, and let you deal with it.