### PR TITLE
fix(parse): Handle errors/warnings which use new lines.

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -163,8 +163,8 @@ module.exports = {
       lines.unshift('');
     }
 
-    let [, message] = lines;
-    message = message || 'webpack-stylish: <please report unknown message format>';
+    let [, ...message] = lines;
+    message = message.length > 0 ? message.join('\n') : 'webpack-stylish: <please report unknown message format>';
 
     if (rePosition.test(message)) {
       // warnings position format (beginning of the message)


### PR DESCRIPTION
<!--
  ZOMG a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and @ken_wheeler
  will appear and pile-drive the close button from a great height while making
  animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

I noticed that when using this package with https://github.com/darrenscerri/duplicate-package-checker-webpack-plugin, all but the first line of the warning was cut off. After some debugging, it seems that package already puts new lines (`\n`) in its output.

The logic in this package seems to assume the message body will not contain new lines -- and if it does, it will cut them off inadvertently.

I've made a change to keep the whole message, even if it contains new lines already.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

I *think* it's fine. But its quite hard to reverse engineer the original purpose of the string manipulation stuff. A keen eye by the author would be appreciated.

### Additional Info
